### PR TITLE
Make deploying new images easier

### DIFF
--- a/.github/workflows/deploy-tumble-prod.yml
+++ b/.github/workflows/deploy-tumble-prod.yml
@@ -2,6 +2,19 @@ name: Deploy Tumble on DigitalOcean Cluster
 
 on:
   workflow_dispatch:
+    inputs:
+      backend_image:
+        type: string
+        description: Docker backend image to deploy
+        default: "ghcr.io/tumble-for-kronox/tumble-backend-dotnet-7.0-amd64:1.4.0"
+      frontend_image:
+        type: string
+        description: Docker frontend image to deploy
+        default: "ghcr.io/tumble-for-kronox/tumble-frontend-web:latest"
+      upgrade_images:
+        type: boolean
+        description: Whether to upgrade the deployment
+        default: false
 
 jobs:
   setup-environment:
@@ -40,4 +53,8 @@ jobs:
 
       - name: Run Ansible Playbook
         run: |
-          ansible-playbook ansible/playbooks/deploy/prod-tumble.yml --vault-password-file vault_pass.txt
+          ansible-playbook ansible/playbooks/deploy/prod-tumble.yml \
+          -e frontend_image="${{ github.event.inputs.frontend_image }}" \
+          -e backend_image="${{ github.event.inputs.backend_image }}" \
+          -e is_upgrade="${{ github.event.inputs.is_upgrade }}" \
+          --vault-password-file vault_pass.txt

--- a/ansible/playbooks/deploy/prod-tumble.yml
+++ b/ansible/playbooks/deploy/prod-tumble.yml
@@ -11,12 +11,14 @@
         kubectl delete secret tumble-backend-secrets -n production
       ignore_errors: yes
       no_log: yes
+      when: is_upgrade
 
     - name: Create Docker registry secret
       command: >
         kubectl create secret docker-registry ghcr-secret -n production
         --docker-server=ghcr.io --docker-username=adisve
         --docker-password={{ ghcr_token }}
+      when: is_upgrade
 
     - name: Create secrets from file
       command: >
@@ -32,8 +34,14 @@
           --from-literal=TestUser__Email={{ testuser_email }} \
           --from-literal=TestUser__Pass={{ testuser_pass }} \
           -n production
+      when: is_upgrade
 
     - name: Deploy Tumble components using helm template
       shell: |
-        helm template tumble ../../../../settings/prod/tumble --values=../../../../settings/prod/tumble/values.yaml -n production > /tmp/tumble.yml
+        helm template tumble ../../../../settings/prod/tumble \
+        --values=../../../../settings/prod/tumble/values.yaml \
+        --set tumble.backend_image={{ backend_image }} \
+        --set tumble.frontend_image={{ frontend_image }} \
+        -n production > /tmp/tumble.yml
+
         kubectl apply -f /tmp/tumble.yml -n production

--- a/settings/prod/tumble/templates/backend/deployment.yml
+++ b/settings/prod/tumble/templates/backend/deployment.yml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: {{ .Release.Name }}-backend
-          image: ghcr.io/tumble-for-kronox/tumble-backend-dotnet-7.0-amd64:1.4.0
+          image: {{ .Values.tumble.backend_image }}
           imagePullPolicy: Always
           resources:
             requests:

--- a/settings/prod/tumble/templates/frontend/deployment.yml
+++ b/settings/prod/tumble/templates/frontend/deployment.yml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: {{ .Release.Name }}-frontend
-          image: ghcr.io/tumble-for-kronox/tumble-frontend-web:latest
+          image: {{ .Values.tumble.frontend_image }}
           imagePullPolicy: Always
           resources:
             requests:

--- a/settings/prod/tumble/values.yaml
+++ b/settings/prod/tumble/values.yaml
@@ -1,8 +1,6 @@
 tumble:
-  image:
-    repository: advee/tumble
-    tag: 1.0.0
-    pullPolicy: Always
+  backend_image: "ghcr.io/tumble-for-kronox/tumble-backend-dotnet-7.0-amd64:1.4.0"
+  frontend_image: "ghcr.io/tumble-for-kronox/tumble-frontend-web:latest"
   service:
     type: ClusterIP
     port: 80


### PR DESCRIPTION
The deploy-tumble-prod.yml GitHub workflow now includes the options to specify just doing an image update on the backend and frontend. This makes it easier to push out new changes through our repository.